### PR TITLE
fix: add missing dependencies to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,9 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <build_depend>tensorrt_cmake_module</build_depend>
+
+  <depend>eigen</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>yaml-cpp</depend>


### PR DESCRIPTION
Eigen and tensorrt_cmake_modules are used in [CMakeLists.txt](https://github.com/autowarefoundation/bevdet_vendor/blob/143465b355ef3e885174f6ea0bf4eb273ca6bb83/CMakeLists.txt#L38), but not defined in package.xml.
This will fix the issue.