### PR TITLE
fix: link CCCL::CCCL for host compilation with CUDA 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ if(NOT (CUDAToolkit_FOUND AND TENSORRT_FOUND))
   return()
 endif()
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/find_cccl.cmake)
+
 set(bevdet_source_files
   src/bevdet.cpp
 
@@ -79,6 +81,7 @@ target_include_directories(
 
 target_link_libraries(
   ${PROJECT_NAME}
+  CCCL::CCCL
   CUDA::cudart
   yaml-cpp
   ${NVINFER}
@@ -115,4 +118,4 @@ ament_export_dependencies(
   "TENSORRT"
 )
 
-ament_package()
+ament_package(CONFIG_EXTRAS cmake/find_cccl.cmake)

--- a/cmake/find_cccl.cmake
+++ b/cmake/find_cccl.cmake
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Autoware Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+# CUDA 13 moved the CCCL headers (Thrust, CUB, libcu++) to include/cccl/.
+# Only nvcc adds that directory to its include path. The CCCL CMake config
+# is outside the default search path, so find_package needs the hints.
+# find_package searches the hints after CCCL_ROOT and CMAKE_PREFIX_PATH but
+# before the system prefixes, so the toolkit config wins over a system copy
+# and explicit user overrides still win over the hints.
+
+find_package(CUDAToolkit REQUIRED)
+find_package(CCCL CONFIG REQUIRED HINTS
+  "${CUDAToolkit_LIBRARY_DIR}/cmake"
+  "${CUDAToolkit_TARGET_DIR}/lib64/cmake"
+  "${CUDAToolkit_TARGET_DIR}/lib/cmake")


### PR DESCRIPTION
## Description

CUDA 13 moved the Thrust, CUB and libcu++ headers from `include/` to `include/cccl/`. `nvcc` adds the new directory by itself. The host compiler does not. `src/bevdet.cpp` includes `<thrust/sort.h>` and is compiled by g++, so the build fails:

```text
src/bevdet.cpp:6:10: fatal error: thrust/sort.h: No such file or directory
```

- <https://developer.nvidia.com/blog/whats-new-and-important-in-cuda-toolkit-13-0/#cccl_headers_have_moved_in_cuda_130>

The fix links `CCCL::CCCL`, which is what the NVIDIA blog above recommends. That target carries the right include directory on CUDA 12 and on CUDA 13, so the code needs no version branch.

The toolkit installs the CCCL CMake config outside the default search path, so a plain `find_package(CCCL)` fails on Ubuntu. `cmake/find_cccl.cmake` passes three hints to cover the native, cross and SBSA toolkit layouts. Hints rank below `CMAKE_PREFIX_PATH` and above the system prefixes, so a user override still wins and a stray system copy does not.

The link is public and the finder ships to consumers. The reason is the installed `iou3d_nms.h`, which includes seven Thrust headers that downstream host files pull in. A build tree only link fails the downstream at `iou3d_nms.h:9`. Those seven includes are unused, and once they are gone the link can become private and the finder can go.

- Follow-up: #6

## Related links

- autowarefoundation/autoware#7108 added `thrust` and `cub` symlinks plus `CPATH=/usr/local/cuda/include/cccl` to the Docker images. That masked the problem in containers. Native Ansible installs have no such bridge and fail.
- autowarefoundation/autoware_universe#12131 fixes the same problem in `autoware_cuda_pointcloud_preprocessor`, and this PR follows the `CCCL::CCCL` recommendation from that review. The hints differ: `${CUDAToolkit_TARGET_DIR}/targets/${CMAKE_SYSTEM_PROCESSOR}-linux` nests `targets/` twice and misses the SBSA layout.

## Known limitation

`cmake/find_cccl.cmake` uses `find_package(... REQUIRED)` and ships as a config extra. If the CCCL config is missing, an optional `find_package(bevdet_vendor)` stops the configure instead of setting `bevdet_vendor_FOUND` to false. Every apt-installed toolkit ships the config, because `cuda-cudart-dev-*` depends on `cuda-cccl-*`. The follow-up above removes the file and this limitation together.

**AI usage:** written with Claude Code: root-cause analysis of the CUDA 13 build failure, the CMake change, and this PR text.

**Self-review:** Done, compiles well on both CUDA 12.8 and 13.0

<details>
<summary><strong>Verification:</strong> <code>bevdet_vendor</code> and its downstream <code>autoware_tensorrt_bevdet</code> build under CUDA 13.0 and under CUDA 12.8, from clean build and install bases.</summary>

Ubuntu 24.04, ROS 2 Jazzy, CMake 3.28.3, GCC 13.3, x86_64, TensorRT 10.8.0. CUDA 13.0.88 and CUDA 12.8.93, both installed.

### Builds

- `main` on CUDA 13.0: `fatal error: thrust/sort.h` at `src/bevdet.cpp:6`, `exited with code 2`.
- This branch on CUDA 13.0: `bevdet_vendor` and `autoware_tensorrt_bevdet` each printed `Summary: 1 package finished`.
- This branch on CUDA 12.8: both packages each printed `Summary: 1 package finished`.
- On 12.8 the downstream compile flags match the `main` baseline, except `-DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA` and `-DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP`. Both equal the compiled-in Thrust defaults.
- On 13.0 the downstream `flags.make` contains `-I/usr/local/cuda-13.0/include/cccl`, received only through the imported target and the config extra.
- `bevdet_vendorConfig.cmake` lists `find_cccl.cmake` before `ament_cmake_export_targets-extras.cmake`, so `CCCL::CCCL` exists before the target import.
- The generated `.cu` rule carries `CUDA_NVCC_COMPILE_DEFINITIONS` with both Thrust definitions, so `.cu` and `.cpp` files agree.

### Finder

- Without hints, `find_package(CCCL CONFIG)` sets `CCCL_FOUND=0` on both toolkits, with `/usr/local/cuda/bin` on `PATH`.
- With the hints: `CCCL_VERSION=3.0.1.0` on 13.0 and `2.7.0.0` on 12.8.
- A fake config passed through `-DCMAKE_PREFIX_PATH` wins over the hints. The same config passed through `-DCMAKE_SYSTEM_PREFIX_PATH` loses to them.
- Two `include()` calls plus one from a subdirectory configure cleanly, so the file is idempotent.

### Not run

- aarch64 and SBSA. The SBSA claim rests on the toolkit layout, not on a build on such a device.
- Ubuntu 22.04 and Humble.
- Runtime inference. No engine was built and no model ran.
- The limitation above was reproduced with a toolkit tree that omits `lib/cmake`, not on a machine that lacks `cuda-cccl`.

</details>
