### PR TITLE
chore: remove unused Thrust includes from iou3d_nms.h

### DIFF
--- a/include/iou3d_nms.h
+++ b/include/iou3d_nms.h
@@ -6,13 +6,6 @@ All Rights Reserved 2019-2022.
 #pragma once
 
 #include <stdio.h>
-#include <thrust/count.h>
-#include <thrust/device_vector.h>
-#include <thrust/gather.h>
-#include <thrust/host_vector.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-#include <thrust/transform.h>
 
 #include <vector>
 #include <iostream>


### PR DESCRIPTION
## Description

`include/iou3d_nms.h` included seven Thrust headers. No header in this repository uses a `thrust::` symbol, and `src/iou3d_nms.cu` uses none either. This PR deletes the seven includes.

- Closes #6

The header is installed. Downstream host translation units reach it through `bevdet.h` -> `postprocess.h` -> `iou3d_nms.h`. Each of them compiled the seven Thrust headers for nothing. After this change, the two host objects of `autoware_tensorrt_bevdet` depend on zero Thrust headers instead of 371.

The two translation units that use `thrust::` symbols, `src/postprocess.cu` and `src/bevdet.cpp`, include their own Thrust headers and are not changed.

## What stays the same

The `CCCL::CCCL` link stays public, and `cmake/find_cccl.cmake` still ships as a config extra. The downstream compile line still carries `-I/usr/local/cuda/include/cccl` on CUDA 13. Both can go in a later PR, together with the switch from `cuda_add_library` to `add_library` plus `enable_language(CUDA)`. The plain `target_link_libraries` signature in this file cannot mix with a `PRIVATE` keyword, so that change touches every link line and is a separate topic.

- The link and the finder came from #5

## Caveat

External code that relied on the transitive Thrust includes must add its own includes. A grep of the Autoware workspace found no such code, and `autoware_tensorrt_bevdet` contains no `thrust` reference.

## AI usage

**AI usage:** written with Claude Code from the issue: the include analysis, the two builds, and this PR text.

**Self-review:** I had it verified for both supported cuda versions. Also nothing downstream breaks because of this PR. Good to merge.

<details>
<summary><strong>Verification:</strong> <code>bevdet_vendor</code> and <code>autoware_tensorrt_bevdet</code> build from clean build directories under CUDA 13.0 and under CUDA 12.8. The downstream host objects no longer depend on any Thrust header.</summary>

Ubuntu 24.04, ROS 2 Jazzy, CMake 3.28.3, GCC 13.3, x86_64. CUDA 13.0.88 and CUDA 12.8, both installed.

### Baseline from the previous local build

The objects in `build/` came from a build of the header with the seven includes, made before this change.

- `bevdet_node.cpp.o.d` and `ros_utils.cpp.o.d` in `build/autoware_tensorrt_bevdet` each listed 371 files under `thrust/`.
- `bevdet.cpp.o.d` in `build/bevdet_vendor` listed 371. The other four host objects of the vendor listed 0.
- Not run: a fresh build of `main`. The counts come from the objects of the previous build.

### Build on CUDA 13.0

`colcon build --symlink-install --packages-select bevdet_vendor autoware_tensorrt_bevdet --cmake-args -DCMAKE_BUILD_TYPE=Release`, after `rm -rf` of the two build directories and the two install directories.

- `Summary: 2 packages finished [53.6s]`, exit status 0.
- `CUDA_VERSION:STRING=13.0` and `CCCL_DIR:PATH=/usr/local/cuda/lib64/cmake/cccl` in both caches.
- `bevdet_node.cpp.o.d` and `ros_utils.cpp.o.d` list 0 files under `thrust/`. Both still list `iou3d_nms.h`.
- `bevdet.cpp.o.d` lists 300 files under `thrust/`, down from 371. `src/bevdet.cpp` includes `thrust/sort.h` and `thrust/functional.h` itself.
- The downstream `flags.make` still carries `-I/usr/local/cuda/include/cccl`, because the link stays public.
- The log has 28 warning lines: nvcc `#177-D` unused variables in the plugin `.cu` files, and CMake policy warnings for `find_package(CUDA)`. None names `thrust`, `cccl` or `iou3d_nms`.
- Not run: aarch64 and SBSA, Ubuntu 22.04 and Humble, and runtime inference. No engine was built and no model ran.

### Build on CUDA 12.8

The same command ran with `--build-base` and `--install-base` in a scratch directory, `PATH=/usr/local/cuda-12.8/bin:$PATH`, and `-DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.8 -DCUDAToolkit_ROOT=/usr/local/cuda-12.8`.

- `Summary: 2 packages finished [52.5s]`, exit status 0.
- `CUDA_NVCC_EXECUTABLE:FILEPATH=/usr/local/cuda-12.8/bin/nvcc`, `CUDA_VERSION:STRING=12.8` and `CCCL_DIR:PATH=/usr/local/cuda-12.8/lib64/cmake/cccl` in the caches. `bevdet_vendor_DIR` points to the scratch install, not to the workspace install.
- `bevdet_node.cpp.o.d` and `ros_utils.cpp.o.d` list 0 files under `thrust/`.
- No `cccl` include directory in the downstream `flags.make`. On CUDA 12 the headers sit in `include/`, which is on the path already.
- The log has 59 warning lines. None names `thrust`, `cccl` or `iou3d_nms`.
- Not run: the same platforms as above, and runtime inference.

### Consumer grep

- `grep` for `thrust` in `autoware_tensorrt_bevdet`: no match.
- `grep` for includes of `bevdet_vendor/`, `iou3d_nms.h`, `postprocess.h` or `bevdet.h` in `src/`, outside the vendor: one match, `ros_utils.hpp:29` with `#include <bevdet.h>`.
- Not run: a grep of code outside this workspace. The caveat above covers that case.

### Binary comparison of `main` and this branch

`bevdet_vendor` and `autoware_tensorrt_bevdet` built twice into the same scratch build path on CUDA 13.0. One build had the vendor at `main` (`e8af87b`), the other at this branch (`1fe2a8d`). The objects and libraries were compared with `cmp`, `nm`, `size`, `readelf`, `objdump` and `cuobjdump`.

- Vendor host objects `bevdet.cpp.o`, `data.cpp.o`, `cpu_jpegdecoder.cpp.o`, `nvjpegdecoder.cpp.o` and `precision_config.cpp.o` are byte-identical.
- `postprocess.cu.o`, `preprocess.cu.o` and the four plugin `.cu.o` differ in 3 to 6 bytes: the `tmpxft_<pid>` temp name that nvcc embeds. Their PTX and SASS are identical.
- `iou3d_nms.cu.o` shrinks from 889520 to 737736 bytes. It loses 45 one-byte Thrust and libcu++ globals, the CUB `EmptyKernel<void>` stub, and the NVTX injection code. The undefined references to `dlopen`, `dlsym`, `dlclose`, `getenv` and `sched_yield` go with them.
- The PTX of the seven `iou3d_nms` kernels is identical. In the SASS, 80 instructions change one operand, `c[0x4][0x168]` to `c[0x4][0x0]`. That operand is the address of `__cudart_i2opi_f`, the only data left in the module. The 45 removed globals took 360 bytes at 8-byte alignment in constant bank 4, so the table moved to offset 0.
- `libbevdet_vendor.so`: same `NEEDED` list, same 633 exported and 307 imported symbols. `.text` shrinks by 2160 bytes and `.nv_fatbin` by 8328 bytes.
- Downstream `ros_utils.cpp.o`, `marker_utils.cpp.o`, `node_main_autoware_tensorrt_bevdet_node.cpp.o` and the `autoware_tensorrt_bevdet_node` executable are byte-identical.
- Downstream `bevdet_node.cpp.o` has the same 4471 sections and 1651 functions. The `__COUNTER__` suffix in the `RCLCPP_COMPONENTS_REGISTER_NODE` helpers changes from 16 to 0, because the Thrust headers consumed 16 counter values.
- `libautoware_tensorrt_bevdet_component.so` keeps the same 26 `NEEDED` entries and 2433 exported symbols. With that suffix normalized, all 2439 functions are identical. `.strtab` is 3 bytes shorter.
- Not run: the same comparison on CUDA 12.8.

### Consumers on other branches and on GitHub

- `autoware_universe` `origin/humble` and `origin/main` both hold `autoware_tensorrt_bevdet` with no `thrust` reference. `release/v1.0` predates the package.
- `autoware` `origin/humble` and `origin/main` both pin `bevdet_vendor` at `0.1.0`. This change reaches them only through a new tag and a `.repos` bump.
- `autoware_perception_launch` is the only other package that names `autoware_tensorrt_bevdet`, as an `exec_depend`. No file outside the package includes its headers.
- GitHub code search for `bevdet_vendor` in `package.xml` and `CMakeLists.txt` files finds only copies of `autoware_tensorrt_bevdet` in forks of `autoware_universe`. The C++ files that include `bevdet.h` and name `thrust` are all copies of the original `bevdet.cpp`, which includes its own Thrust headers.

</details>
