### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bevdet_vendor</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The bevdet tensorrt package</description>
 
   <maintainer email="cynthia.liu@autocore.ai">cyn-liu</maintainer>


### PR DESCRIPTION
## Description

`package.xml` stayed at `0.0.0` through the `0.1.0` tag. This PR sets it to `0.2.0`, the version of the next release. The release tag goes on the merge commit of this PR.

- Previous release: https://github.com/autowarefoundation/bevdet_vendor/releases/tag/0.1.0
