### PR TITLE
build: make the CCCL::CCCL link private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(bevdet_source_files
   src/precision_config.cpp
 )
 
+set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)
 cuda_add_library(${PROJECT_NAME} SHARED
   ${bevdet_source_files}
 )
@@ -81,7 +82,7 @@ target_include_directories(
 
 target_link_libraries(
   ${PROJECT_NAME}
-  CCCL::CCCL
+  PUBLIC
   CUDA::cudart
   yaml-cpp
   ${NVINFER}
@@ -89,6 +90,8 @@ target_link_libraries(
   ${TENSORRT_LIBRARIES}
   ${CUDA_LIBRARIES}
   ${CUBLAS_LIBRARIES}
+  PRIVATE
+  CCCL::CCCL
 )
 
 set_target_properties(${PROJECT_NAME}
@@ -118,4 +121,4 @@ ament_export_dependencies(
   "TENSORRT"
 )
 
-ament_package(CONFIG_EXTRAS cmake/find_cccl.cmake)
+ament_package()

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bevdet_vendor</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The bevdet tensorrt package</description>
 
   <maintainer email="cynthia.liu@autocore.ai">cyn-liu</maintainer>


### PR DESCRIPTION
## Description

No installed header includes a CCCL header any more. The public interface of `bevdet_vendor` is TensorRT, `nvjpeg.h`, `cuda_runtime.h`, yaml-cpp and Eigen. Only `src/bevdet.cpp`, `src/postprocess.cu` and `src/preprocess.cu` use Thrust, and they are private to the library.

The `CCCL::CCCL` link was public and `cmake/find_cccl.cmake` shipped as a config extra for one reason: the installed `iou3d_nms.h` included Thrust. That reason is gone.

- The public link and the finder came from #5
- The includes went away in #7

This PR makes the link `PRIVATE` and stops the `CONFIG_EXTRAS` export. `include(cmake/find_cccl.cmake)` stays, because the library itself needs CCCL at build time. `package.xml` moves to `0.2.1` for the release that follows.

## What consumers see

- The exported target no longer lists `CCCL::CCCL` in `INTERFACE_LINK_LIBRARIES`.
- The consumer compile line loses `-I/usr/local/cuda/include/cccl` and the two `-DTHRUST_*_SYSTEM` definitions.
- `find_package(bevdet_vendor)` no longer runs `find_package(CCCL REQUIRED)`. The known limitation from #5 is gone.
- The only consumer, `autoware_tensorrt_bevdet`, has no `thrust` reference and compiles to byte-identical objects.

## Why `set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)`

`cuda_add_library` calls `target_link_libraries(${cuda_target} ${CUDA_LINK_LIBRARIES_KEYWORD} ${CUDA_LIBRARIES})` inside FindCUDA. The variable is empty by default, so that call uses the plain signature. CMake then rejects a later keyword call on the same target:

```text
CMake Error at CMakeLists.txt:82 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "bevdet_vendor".  All uses of target_link_libraries with a
  target must be either all-keyword or all-plain.
```

With the variable set to `PUBLIC`, the internal call uses the keyword signature, and the `PRIVATE` keyword becomes possible. `PUBLIC` keeps the previous behavior for `${CUDA_LIBRARIES}`. The plain signature already exported them, and the exported `INTERFACE_LINK_LIBRARIES` still lists `libcudart_static.a`, `Threads::Threads`, `dl` and `librt.a`.

- Issue #6 expected the switch from `cuda_add_library` to `add_library` first. This variable makes that switch unnecessary for this step.

## AI usage

**AI usage:** written with Claude Code: the interface analysis, the CMake change, the builds and comparisons, and this PR text.

**Self-review:** Done and verified.

<details>
<summary><strong>Verification:</strong> Clean scratch builds of <code>bevdet_vendor</code> and <code>autoware_tensorrt_bevdet</code> on CUDA 13.0 and CUDA 12.8. The consumer loses the CCCL include directory and definitions, and its objects stay byte-identical.</summary>

Ubuntu 24.04, ROS 2 Jazzy, CMake 3.28.3, GCC 13.3, x86_64. CUDA 13.0.88 and CUDA 12.8, both installed. The builds ran on the CMake change. The `package.xml` version line was added after, and `catkin_pkg` parses it as `0.2.1`.

### Build on CUDA 13.0

`colcon build --packages-select bevdet_vendor autoware_tensorrt_bevdet --cmake-args -DCMAKE_BUILD_TYPE=Release` into a clean scratch build base.

- `Summary: 2 packages finished [30.5s]`, exit status 0.
- Installed `share/bevdet_vendor/cmake/` has no `find_cccl.cmake`. The `_extras` list in `bevdet_vendorConfig.cmake` holds only the two ament extras.
- `export_bevdet_vendorExport.cmake`: `INTERFACE_LINK_LIBRARIES` lists `CUDA::cudart`, `yaml-cpp`, `libnvinfer.so` and no `CCCL::CCCL`.
- Downstream `flags.make`: 0 `include/cccl` entries, 0 `THRUST_*_SYSTEM` definitions. Before: 1 and 2.
- Vendor `flags.make`: 1 `include/cccl` entry, 2 Thrust definitions. The `.cu` rule `bevdet_vendor_generated_postprocess.cu.o.RELEASE.cmake` carries both too.
- Downstream `bevdet_node.cpp.o`, `ros_utils.cpp.o`, `marker_utils.cpp.o`, `node_main_autoware_tensorrt_bevdet_node.cpp.o` and the `autoware_tensorrt_bevdet_node` executable are byte-identical to the build of `main` in the same path.
- Not run: aarch64 and SBSA, Ubuntu 22.04 and Humble, runtime inference.

### Build on CUDA 12.8

Same command with `PATH=/usr/local/cuda-12.8/bin:$PATH`, `-DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.8 -DCUDAToolkit_ROOT=/usr/local/cuda-12.8`, clean scratch bases.

- `Summary: 2 packages finished [27.6s]`, exit status 0. `CUDA_VERSION:STRING=12.8`, `CCCL_DIR:PATH=/usr/local/cuda-12.8/lib64/cmake/cccl`.
- No `find_cccl.cmake` installed, no `CCCL::CCCL` in the export.
- Downstream `flags.make`: 0 `include/cccl` entries, 0 Thrust definitions. Vendor `flags.make`: 2 Thrust definitions.
- The five downstream files are byte-identical to the previous 12.8 build in the same path.
- Not run: the same platforms as above, and runtime inference.

### Configure without `CUDA_LINK_LIBRARIES_KEYWORD`

A copy of the source with the `set()` line removed, configured with `cmake -S ... -B ...` in the sourced workspace.

- `cmake` exit status 1, with the error quoted above at `CMakeLists.txt:82`.
- With the line in place: exit status 0, no `CMake Error`.
- Not run: a full build of that copy. The configure error stops it.

</details>
